### PR TITLE
add gen_virtual_depth.sh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+data/
+weights/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /root/Depth4ToM-code
 
 RUN apt update && apt install -y eog nano
 COPY reinstall-opencv.sh /root/Depth4ToM-code
-
+COPY gen_virtual_depth.sh /root/Depth4ToM-code/scripts

--- a/gen_virtual_depth.sh
+++ b/gen_virtual_depth.sh
@@ -1,4 +1,4 @@
-root="/root/Depth4ToM/data/Trans10K"
+root="/root/Depth4ToM/data"
 cd ..
 
 model="dpt_large" # ["midas_v21", "dpt_large"]

--- a/gen_virtual_depth.sh
+++ b/gen_virtual_depth.sh
@@ -1,0 +1,34 @@
+root="/root/Depth4ToM/data/Trans10K"
+cd ..
+
+model="dpt_large" # ["midas_v21", "dpt_large"]
+dataset="Trans10K" # ["Trans10K", "MSD"]
+splits="train test validation"
+for split in $splits
+do
+    echo $model $dataset $split
+    input_dir=$root/$dataset/$split/images # path to dataset folder with images
+    mask_dir=$root/$dataset/$split/masks # path to dataset folder with segmentations, either GT or proxy
+    output_dir=$root"/"$dataset/$split/$model"_proxies"/$exp # output path
+    
+    dataset_lower=$(echo $dataset | tr '[:upper:]' '[:lower:]')
+    dataset_txt="datasets/"$dataset_lower"/"$split".txt" # inference list
+
+    ### define output_list if you want to save the list of the generated virtual depths
+    exp="base"
+    output_list="datasets/"$dataset_lower"/"$split"_"$model"_"$exp".txt"
+    ###
+    
+    if [ -f $dataset_txt ]
+    then
+        python3 run.py --model_type $model \
+                    --input_path $input_dir \
+                    --dataset_txt $dataset_txt \
+                    --output_path $output_dir \
+                    --output_list $output_list \
+                    --mask_path $mask_dir \
+                    --it 5 \
+                    --cls2mask 255 # list of class ids in segmentation maps relative to ToM surfaces.
+    fi
+done
+

--- a/gen_virtual_depth.sh
+++ b/gen_virtual_depth.sh
@@ -1,4 +1,4 @@
-root="/root/Depth4ToM/data"
+root="/root/Depth4ToM-code/data"
 cd ..
 
 model="dpt_large" # ["midas_v21", "dpt_large"]


### PR DESCRIPTION
# why
- まだ、run.pyを含むシェルスクリプトが動作していない。
# what
- gen_virtual_depth.sh を追加。
	- これをdocker環境のscripts にCOPY
	- dataのあるpathの問題をユーザー環境に合わせた。
- .dockerignore を追加
data/, weights/ を記入した。そうしないとdockerかこれらを管理しようとして極端に遅くなる。
## 動作状況
docker環境内で以下のスクリプトが動作を開始した。
```
cd scripts
bash gen_virtual_depth.sh
 ```

ただし、データの量が莫大なので、数日かかるかもしれない。